### PR TITLE
Allow 'ROLLBACK' as a read-only operation as well

### DIFF
--- a/src/django_read_only.py
+++ b/src/django_read_only.py
@@ -75,7 +75,7 @@ def should_block(sql):
                 "SET ",
             )
         )
-        and sql not in ("BEGIN", "COMMIT")
+        and sql not in ("BEGIN", "COMMIT", "ROLLBACK")
     )
 
 


### PR DESCRIPTION
Most calls for this will come through the DB-API `rollback` method rather than as raw SQL, but for applications that do their own transaction management this may be used.