### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/src/django_read_only/__init__.py
+++ b/src/django_read_only/__init__.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import os
 from contextlib import contextmanager
-from typing import Any, Callable, Generator
+from typing import Any
+from typing import Callable
+from typing import Generator
 
 from django.apps import AppConfig
 from django.conf import settings

--- a/tests/test_django_read_only.py
+++ b/tests/test_django_read_only.py
@@ -7,13 +7,17 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
+from typing import Callable
 from unittest import mock
 
 import pytest
 from django.contrib.sites.models import Site
-from django.db import connection, transaction
-from django.test import SimpleTestCase, TestCase, override_settings
+from django.db import connection
+from django.db import transaction
+from django.test import override_settings
+from django.test import SimpleTestCase
+from django.test import TestCase
 
 import django_read_only
 


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
