### PR TITLE
Upgrade pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ test = [
   "coverage[toml]",
   "ipython",
   "psycopg[binary]",
-  "pytest",
+  "pytest>=9",
   "pytest-django",
   "pytest-randomly",
 ]
@@ -122,13 +122,9 @@ warn_unreachable = true
 overrides = [ { module = "tests.*", allow_untyped_defs = true } ]
 
 [tool.pytest]
-ini_options.addopts = """\
-    --strict-config
-    --strict-markers
-    --ds=tests.settings
-    """
-ini_options.django_find_project = false
-ini_options.xfail_strict = true
+strict = true
+django_find_project = false
+DJANGO_SETTINGS_MODULE = "tests.settings"
 
 [tool.coverage]
 run.branch = true

--- a/uv.lock
+++ b/uv.lock
@@ -233,9 +233,9 @@ name = "django"
 version = "5.2.12"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
+    "python_full_version >= '3.12'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
-    "python_full_version >= '3.12'",
 ]
 dependencies = [
     { name = "asgiref", marker = "(python_full_version < '3.12' and extra != 'group-16-django-read-only-django42' and extra != 'group-16-django-read-only-django50' and extra != 'group-16-django-read-only-django51') or extra == 'group-16-django-read-only-django52' or (extra == 'group-16-django-read-only-django42' and extra == 'group-16-django-read-only-django50') or (extra == 'group-16-django-read-only-django42' and extra == 'group-16-django-read-only-django51') or (extra == 'group-16-django-read-only-django42' and extra == 'group-16-django-read-only-django60') or (extra == 'group-16-django-read-only-django50' and extra == 'group-16-django-read-only-django51') or (extra == 'group-16-django-read-only-django50' and extra == 'group-16-django-read-only-django60') or (extra == 'group-16-django-read-only-django51' and extra == 'group-16-django-read-only-django60')" },
@@ -316,7 +316,7 @@ test = [
     { name = "coverage", extras = ["toml"] },
     { name = "ipython" },
     { name = "psycopg", extras = ["binary"] },
-    { name = "pytest" },
+    { name = "pytest", specifier = ">=9" },
     { name = "pytest-django" },
     { name = "pytest-randomly" },
 ]


### PR DESCRIPTION
Use the new proper TOML support [added in pytest 9](https://docs.pytest.org/en/stable/changelog.html#pytest-9-0-0-2025-11-05).
